### PR TITLE
move linker flags to the end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 all: lighter
 
 lighter: main.o $(OBJECTS)
-	$(CXX) -o $@ $(CXXFLAGS) $(LINKFLAGS) $(OBJECTS) main.o 
+	$(CXX) -o $@ $(CXXFLAGS) $(OBJECTS) main.o $(LINKFLAGS)
 
 main.o: main.cpp utils.h Reads.h Store.h bloom_filter.hpp
 ErrorCorrection.o: ErrorCorrection.cpp ErrorCorrection.h utils.h


### PR DESCRIPTION
See: http://stackoverflow.com/a/1665110/330558

Before the patch, I get:

```
g++ -o lighter -Wall -O -lpthread ErrorCorrection.o KmerCode.o GetKmers.o main.o 
main.o: In function `main':
main.cpp:(.text+0x127f): undefined reference to `pthread_create'
main.cpp:(.text+0x129f): undefined reference to `pthread_join'
main.cpp:(.text+0x1923): undefined reference to `pthread_create'
main.cpp:(.text+0x1943): undefined reference to `pthread_join'
collect2: ld returned 1 exit status
make: *** [lighter] Error 1
```

After the patch, I can `make` successfully.
